### PR TITLE
Remove badges from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@ QueryPath is a jQuery-like library for working with XML and HTML(5) documents in
 
 > If you are viewing this file on QueryPath GitHub repository homepage or on Packagist, please note that the default repository branch is `main` which can differ from the last stable release.
 
-[![Latest Stable Version](https://poser.pugx.org/gravitypdf/querypath/v/stable)](https://packagist.org/packages/gravitypdf/querypath)
-[![Total Downloads](https://poser.pugx.org/gravitypdf/querypath/downloads)](https://packagist.org/packages/gravitypdf/querypath)
-[![License](https://poser.pugx.org/gravitypdf/querypath/license)](https://packagist.org/packages/gravitypdf/querypath)
-
 ## Installation
 ``` 
 composer require gravitypdf/querypath 


### PR DESCRIPTION
They look to be pulling info from the original library, instead of `gravitypdf/querypath` for some reason (maybe the "replace" key in composer.json is the cause. Remove for now.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [X] Documentation content changes
- [ ] Other (please describe):

