### PR TITLE
Refactor PHPUnit

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -11,23 +11,21 @@ jobs:
     name: PHP ${{ matrix.php-versions }} PHPUnit Test
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: composer, cs2pr
+          ini-values: error_reporting=E_ALL
+
+      - name: Install Composer Dependencies
+        uses: "ramsey/composer-install@v2"
 
       - name: Log debug information
         run: |
           php --version
           composer --version
 
-      - name: Install Composer dependencies
-        run: |
-          composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
-          echo "${PWD}/vendor/bin" >> $GITHUB_PATH
-
       - name: Run PHPUnit
-        run: vendor/bin/phpunit
+        run: ./vendor/bin/phpunit

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,9 +1,19 @@
-<phpunit bootstrap="./tests/_bootstrap.php" colors="true">
+<phpunit
+        bootstrap="./tests/_bootstrap.php"
+        colors="true"
+        beStrictAboutTestsThatDoNotTestAnything="true"
+        beStrictAboutOutputDuringTests="true"
+        convertErrorsToExceptions="true"
+        convertWarningsToExceptions="true"
+        convertNoticesToExceptions="true"
+        verbose="true"
+>
     <testsuites>
-        <testsuite name="Words">
-            <directory suffix="Test.php" phpVersion="7.1" phpVersionOperator=">=">./tests/</directory>
+        <testsuite name="unit">
+            <directory>./tests/</directory>
         </testsuite>
     </testsuites>
+
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory>./src/</directory>

--- a/tests/QueryPath/TestCase.php
+++ b/tests/QueryPath/TestCase.php
@@ -7,8 +7,6 @@
 
 namespace QueryPathTests;
 
-require_once __DIR__ . '/../../vendor/autoload.php';
-
 class TestCase extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 {
 	public const DATA_FILE_XML = 'tests/data.xml';

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-phpunit=/Applications/MAMP/bin/php5/bin/phpunit
-$phpunit --coverage-html coverage Tests
-rm "db/qpTest.db"
-rm "db/qpTest2.db"


### PR DESCRIPTION
Explicitly display all PHP errors, notices, deprecations. Use new PHPUnit syntax for XML
Remove extra autoload require statement
Remove old code coverage bash script

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

PHPUnit wasn't reporting deprecation errors correctly and missed a message in the PHP8.1 unit tests.

## What is the new behavior?

PHP8.1 correctly reports an issue with the `QueryPathIterator` class and its return type.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

