### PR TITLE
Resolve PHP8.1 Deprecation Notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 QueryPath Changelog
 ===========================
 
+# 3.2.1
+- Fix QueryPath\QueryPathIterator::current() deprecation notice in PHP8.1
+
 # 3.2.0
 
 - Fixes a number of type-related errors on PHP 8.1

--- a/src/QueryPathIterator.php
+++ b/src/QueryPathIterator.php
@@ -26,6 +26,7 @@ class QueryPathIterator extends IteratorIterator
 	public $options = [];
 	private $qp;
 
+	#[\ReturnTypeWillChange]
 	public function current()
 	{
 		if (! isset($this->qp)) {

--- a/tests/QueryPath/QueryPathIteratorTest.php
+++ b/tests/QueryPath/QueryPathIteratorTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace QueryPathTests;
+
+class QueryPathIteratorTest extends TestCase
+{
+	public function testCurrent()
+	{
+		$qp = qp('<ul><li>Item1</li><li>Item2</li></ul>', 'li');
+
+		$iterator = $qp->getIterator();
+		$iterator->rewind();
+
+		$this->assertSame('Item1', $iterator->current()->text());
+		$iterator->next();
+		$this->assertSame('Item2', $iterator->current()->text());
+	}
+}


### PR DESCRIPTION
Fixes the following in a backwards-compatible way
> PHP Deprecated:  Return type of QueryPath\QueryPathIterator::current() should either be compatible with IteratorIterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/querypath/querypath/src/QueryPathIterator.php on line 29

Resolves #27

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

This notice is triggered when running PHP 8.1

> PHP Deprecated:  Return type of QueryPath\QueryPathIterator::current() should either be compatible with IteratorIterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/querypath/querypath/src/QueryPathIterator.php on line 29

## What is the new behavior?

The notice is no longer present.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
