### PR TITLE
Improve type hinting on primary functions

### DIFF
--- a/src/QueryPath.php
+++ b/src/QueryPath.php
@@ -180,11 +180,14 @@ class QueryPath
 
 
 	/**
-	 * @param null  $document
-	 * @param null  $selector
+	 * @param mixed $document
+	 * @param string|null $selector
 	 * @param array $options
 	 *
 	 * @return mixed|DOMQuery
+	 *
+	 * @see qp()
+	 * @see htmlqp()
 	 */
 	public static function with($document = null, $selector = '', array $options = [])
 	{
@@ -193,6 +196,15 @@ class QueryPath
 		return new $qpClass($document, $selector, $options);
 	}
 
+	/**
+	 * @param mixed $source
+	 * @param string|null $selector
+	 * @param array $options
+	 *
+	 * @return mixed|DOMQuery
+	 *
+	 * @see qp()
+	 */
 	public static function withXML($source = null, $selector = '', array $options = [])
 	{
 		$options += [
@@ -202,6 +214,15 @@ class QueryPath
 		return self::with($source, $selector, $options);
 	}
 
+	/**
+	 * @param mixed $source
+	 * @param string|null $selector
+	 * @param array $options
+	 *
+	 * @return mixed|DOMQuery
+	 *
+	 * @see htmlqp()
+	 */
 	public static function withHTML($source = null, $selector = '', array $options = [])
 	{
 		// Need a way to force an HTML parse instead of an XML parse when the
@@ -240,7 +261,7 @@ class QueryPath
 	 *   of DOMNodes will be passed through as well. However, these types are not
 	 *   validated in any way.
 	 *
-	 * @param string $selector
+	 * @param string|null $selector
 	 *   A CSS3 selector.
 	 *
 	 * @param array  $options
@@ -248,9 +269,11 @@ class QueryPath
 	 *   that the standard QueryPath options may be ignored for this function,
 	 *   since it uses a different parser.
 	 *
-	 * @return QueryPath
+	 * @return mixed|DOMQuery
+	 *
+	 * @see html5qp()
 	 */
-	public static function withHTML5($source = null, $selector = '', $options = [])
+	public static function withHTML5($source = null, $selector = '', array $options = [])
 	{
 		$qpClass = $options['QueryPath_class'] ?? '\QueryPath\DOMQuery';
 
@@ -263,9 +286,7 @@ class QueryPath
 			}
 		}
 
-		$qp = new $qpClass($source, $selector, $options);
-
-		return $qp;
+		return new $qpClass($source, $selector, $options);
 	}
 
 	/**

--- a/src/qp_functions.php
+++ b/src/qp_functions.php
@@ -147,12 +147,12 @@ use QueryPath\QueryPath;
  *
  * @param mixed  $document
  *  A document in one of the forms listed above.
- * @param string $string
+ * @param string|null $string
  *  A CSS 3 selector.
  * @param array  $options
  *  An associative array of options. Currently supported options are listed above.
  *
- * @return DOMQuery
+ * @return mixed|DOMQuery
  *  Or possibly another QueryPath-like object if you overrode QueryPath_class.
  */
 function qp($document = null, $string = '', array $options = [])
@@ -183,16 +183,15 @@ function qp($document = null, $string = '', array $options = [])
  *
  * @ingroup querypath_core
  *
- * @param null   $document
- * @param string $selector
- * @param array  $options
+ * @param mixed $document
+ * @param string|null $selector
+ * @param array $options
  *
  * @return mixed|DOMQuery
  * @see     qp()
  */
-function htmlqp($document = null, $selector = '', $options = [])
+function htmlqp($document = null, $selector = '', array $options = [])
 {
-
 	return QueryPath::withHTML($document, $selector, $options);
 }
 
@@ -209,8 +208,8 @@ function htmlqp($document = null, $selector = '', $options = [])
  * - QueryPath_class
  *
  *
- * @param null   $document
- * @param string $selector
+ * @param mixed $document
+ * @param string|null $selector
  *   A CSS3 selector.
  *
  * @param array  $options
@@ -218,9 +217,9 @@ function htmlqp($document = null, $selector = '', $options = [])
  *   that the standard QueryPath options may be ignored for this function,
  *   since it uses a different parser.
  *
- * @return QueryPath
+ * @return mixed|DOMQuery
  */
-function html5qp($document = null, $selector = null, array $options = [])
+function html5qp($document = null, $selector = '', array $options = [])
 {
 	return QueryPath::withHTML5($document, $selector, $options);
 }


### PR DESCRIPTION
The `html5qp()` function wasn't correctly type hinted + the signature didn't match `qp()` or `htmlqp()`, and this PR fixes that issue. The docblock property types were tweaked/added in the primary functions, and their `QueryPath` class equivalent, to better match the inputs / return values. 

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [X] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
