### PR TITLE
Prepare 3.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 QueryPath Changelog
 ===========================
 
+# 3.2.2
+
+- Add PHP 8.2 Support
+
 # 3.2.1
+
 - Fix QueryPath\QueryPathIterator::current() deprecation notice in PHP8.1
 
 # 3.2.0

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "gravitypdf/querypath",
   "type": "library",
-  "description": "PHP library for HTML(5)/XML querying (CSS 4 or XPath) and processing (like jQuery) with PHP8.1 support",
+  "description": "PHP library for HTML(5)/XML querying (CSS 4 or XPath) and processing (like jQuery) with PHP8.2 support",
   "homepage": "https://github.com/gravitypdf/querypath",
   "license": "MIT",
   "keywords": [

--- a/src/QueryPath.php
+++ b/src/QueryPath.php
@@ -110,7 +110,7 @@ class QueryPath
 	 *
 	 * @since 2.0
 	 */
-	public const VERSION = '3.0.x';
+	public const VERSION = '3.2.2';
 
 	/**
 	 * Major version number.


### PR DESCRIPTION
Enable PHP8.2, update `QueryPath::VERSION` number to 3.2.2, and prepare changelog.
