### PR TITLE
Restore Interface Contract in DOM.php

### DIFF
--- a/src/DOM.php
+++ b/src/DOM.php
@@ -65,7 +65,7 @@ abstract class DOM implements Query, IteratorAggregate, Countable
 	 *
 	 * @param mixed  $document
 	 *   A document-like object.
-	 * @param string $string
+	 * @param string|null $string
 	 *   A CSS 3 Selector
 	 * @param array  $options
 	 *   An associative array of options.
@@ -73,14 +73,9 @@ abstract class DOM implements Query, IteratorAggregate, Countable
 	 * @throws Exception
 	 * @see qp()
 	 */
-	public function __construct($document = null, $string = '', $options = [])
+	public function __construct($document = null, $string = null, $options = [])
 	{
-		// Backwards compatibility fix for PHP8+
-		if (is_null($string)) {
-			$string = '';
-		}
-
-		$string        = trim($string);
+		$string        = is_string($string) ? trim($string) : '';
 		$this->options = $options + Options::get() + $this->options;
 
 		$parser_flags = $options['parser_flags'] ?? self::DEFAULT_PARSER_FLAGS;

--- a/src/QueryPath.php
+++ b/src/QueryPath.php
@@ -189,7 +189,7 @@ class QueryPath
 	 * @see qp()
 	 * @see htmlqp()
 	 */
-	public static function with($document = null, $selector = '', array $options = [])
+	public static function with($document = null, $selector = null, array $options = [])
 	{
 		$qpClass = $options['QueryPath_class'] ?? '\QueryPath\DOMQuery';
 
@@ -205,7 +205,7 @@ class QueryPath
 	 *
 	 * @see qp()
 	 */
-	public static function withXML($source = null, $selector = '', array $options = [])
+	public static function withXML($source = null, $selector = null, array $options = [])
 	{
 		$options += [
 			'use_parser' => 'xml',
@@ -223,7 +223,7 @@ class QueryPath
 	 *
 	 * @see htmlqp()
 	 */
-	public static function withHTML($source = null, $selector = '', array $options = [])
+	public static function withHTML($source = null, $selector = null, array $options = [])
 	{
 		// Need a way to force an HTML parse instead of an XML parse when the
 		// doctype is XHTML, since many XHTML documents are not valid XML
@@ -273,7 +273,7 @@ class QueryPath
 	 *
 	 * @see html5qp()
 	 */
-	public static function withHTML5($source = null, $selector = '', array $options = [])
+	public static function withHTML5($source = null, $selector = null, array $options = [])
 	{
 		$qpClass = $options['QueryPath_class'] ?? '\QueryPath\DOMQuery';
 

--- a/src/qp_functions.php
+++ b/src/qp_functions.php
@@ -155,7 +155,7 @@ use QueryPath\QueryPath;
  * @return mixed|DOMQuery
  *  Or possibly another QueryPath-like object if you overrode QueryPath_class.
  */
-function qp($document = null, $string = '', array $options = [])
+function qp($document = null, $string = null, array $options = [])
 {
 	return QueryPath::with($document, $string, $options);
 }
@@ -190,7 +190,7 @@ function qp($document = null, $string = '', array $options = [])
  * @return mixed|DOMQuery
  * @see     qp()
  */
-function htmlqp($document = null, $selector = '', array $options = [])
+function htmlqp($document = null, $selector = null, array $options = [])
 {
 	return QueryPath::withHTML($document, $selector, $options);
 }
@@ -219,7 +219,7 @@ function htmlqp($document = null, $selector = '', array $options = [])
  *
  * @return mixed|DOMQuery
  */
-function html5qp($document = null, $selector = '', array $options = [])
+function html5qp($document = null, $selector = null, array $options = [])
 {
 	return QueryPath::withHTML5($document, $selector, $options);
 }


### PR DESCRIPTION
In https://github.com/GravityPDF/querypath/commit/35e92660d680f18a332eec10fdc8a6ecc7596fb7 the $selector property was changed from null to '', which broke the Query interface contract.

Restore the contract, instead of updating the interface, to prevent a breaking change.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The interface and the class implementing it were at odds with the type hints.

## What is the new behavior?

Update the class so it matches the interface.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
