### PR TITLE
Reverse logic of html5() Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 QueryPath Changelog
 ===========================
 
+# 3.2.4
+
+- Reverse logic in DomQuery::html5() so that DomQuery::html5() returns the content of the current match, and DomQuery::html5('') replaces the content of the current matches. This matches the existing logic used in DomQuery::html().
+
 # 3.2.3
 
 - Add PHP 8.3 Support

--- a/src/DOMQuery.php
+++ b/src/DOMQuery.php
@@ -708,22 +708,22 @@ class DOMQuery extends DOM
 	}
 
 	/**
-	 * Write the QueryPath document to HTML5.
-	 *
-	 * See html()
+	 * Set or get the markup for an element using the HTML5 parser
 	 *
 	 * @param null|string $markup
 	 *
 	 * @return null|DOMQuery|string
 	 * @throws QueryPath
 	 * @throws \QueryPath\Exception
+	 *
+	 * @see html()
 	 */
 	public function html5($markup = null)
 	{
 		$html5 = new HTML5($this->options);
 
 		// append HTML to existing
-		if ($markup === null) {
+		if (isset($markup)) {
 			// Parse the HTML and insert it into the DOM
 			$doc = $html5->loadHTMLFragment($markup);
 			$this->removeChildren();

--- a/tests/QueryPath/DOMQueryTest.php
+++ b/tests/QueryPath/DOMQueryTest.php
@@ -164,8 +164,45 @@ class DOMQueryTest extends TestCase
 
 	public function testHtml5()
 	{
-		$doc = qp(DATA_HTML_FILE);
-		$this->assertEquals('range', $doc->find('input')->attr('type'));
+		$file = DATA_FILE;
+		$qp   = qp($file, 'unary');
+		$html = '<b>test</b>';
+		$this->assertEquals($html, $qp->html5($html)->find('b')->html5());
+
+		$html = '<html><head><title>foo</title></head><body>bar</body></html>';
+		// We expect a DocType to be prepended:
+		$this->assertEquals('<!DOCTYPE', substr(qp($html)->html5(), 0, 9));
+
+		// Check that HTML is not added to empty finds. Note the # is for a special
+		// case.
+		$this->assertEquals('', qp($html, '#nonexistant')->html5('<p>Hello</p>')->html5());
+		$this->assertEquals('', qp($html, 'nonexistant')->html5('<p>Hello</p>')->html5());
+
+		// We expect NULL if the document is empty.
+		$this->assertNull(qp()->html5());
+
+		// Non-DOMNodes should not be rendered:
+		$fn = 'mapCallbackFunction';
+		$this->assertNull(qp($file, 'li')->map([$this, $fn])->html5());
+
+		// Check html5() getter works correctly
+		$this->assertSame('<span>Content</span>', qp('<span>Content</span>')->find('span')->html5());
+
+		// Check html5() gets the first match only
+		$this->assertSame('<td>Foo</td>', qp(DATA_HTML_FILE, 'td')->html5());
+
+		// Check html5() setter works correctly
+		$this->assertSame('', qp('<span>Content</span>')->html5('')->innerHTML5());
+
+		// Check html5() setter works on all matches
+		$this->assertSame('
+    <tr>
+        <td>FooBar</td>
+    </tr>
+    <tr>
+        <td>FooBar</td>
+    </tr>
+', qp(DATA_HTML_FILE, 'td')->html5('FooBar')->parent('table')->innerHTML5());
 	}
 
 	public function testInnerHtml5()
@@ -1189,6 +1226,25 @@ class DOMQueryTest extends TestCase
 		// Non-DOMNodes should not be rendered:
 		$fn = 'mapCallbackFunction';
 		$this->assertNull(qp($file, 'li')->map([$this, $fn])->html());
+
+		// Check html() getter works correctly
+		$this->assertSame('<span>Content</span>', qp('<span>Content</span>')->find('span')->html());
+
+		// Check html() gets the first match only
+		$this->assertSame('<td>Foo</td>', qp(DATA_HTML_FILE, 'td')->html());
+
+		// Check html() setter works correctly
+		$this->assertSame('', qp('<span>Content</span>')->html('')->innerHTML());
+
+		// Check html() setter works on all matches
+		$this->assertSame('
+    <tr>
+        <td>FooBar</td>
+    </tr>
+    <tr>
+        <td>FooBar</td>
+    </tr>
+', qp(DATA_HTML_FILE, 'td')->html('FooBar')->parent('table')->innerHTML());
 	}
 
 	public function testInnerHTML()


### PR DESCRIPTION
Resolves issue where calling $qp('<strong>Content</strong>')->html5() would return an empty string, and calling $qp('<strong>Content</strong>')->html5('') would return <strong>Content</strong>. The correct logic, per ->html(), is to reverse how this method works.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

If you call `html5()` without a parameter it will return an empty string, instead of the currently loaded document. 

## What is the new behavior?

Calling `html5()` without a parameter will now correctly return the loaded document, and calling `html5('markup')` will correctly set the innerHTML of the currently selected Element. 

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

Technically, if users relied on the previous behavior this would be considered a breaking change. But the previous behavior is functionally incorrect. It should act just like `->html()`, but using the `HTML5()` class. 

## Other information

TODO: Unit test
