### PR TITLE
Fix return value of wrapAll() when count() is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 QueryPath Changelog
 ===========================
 
-# 3.2.4
+# 4.0.0
 
 - Reverse logic in DomQuery::html5() so that DomQuery::html5() returns the content of the current match, and DomQuery::html5('') replaces the content of the current matches. This matches the existing logic used in DomQuery::html().
+- Return DOMQuery object if QueryMutators::wrapAll() has no matches (instead of null). This aligns the method with the Docblock return type.
 
 # 3.2.3
 

--- a/src/Helpers/QueryMutators.php
+++ b/src/Helpers/QueryMutators.php
@@ -453,7 +453,7 @@ trait QueryMutators
 	public function wrapAll($markup)
 	{
 		if ($this->matches->count() === 0) {
-			return;
+			return $this;
 		}
 
 		$data = $this->prepareInsert($markup);

--- a/tests/QueryPath/DOMQueryTest.php
+++ b/tests/QueryPath/DOMQueryTest.php
@@ -1034,6 +1034,9 @@ class DOMQueryTest extends TestCase
 			'li'
 		)->wrapAll('<test class="testWrap"><inside><center/></inside></test>')->get(0)->ownerDocument->saveXML();
 		$this->assertEquals(5, qp($xml, '.testWrap > inside > center > li')->count());
+
+		// verify wrapAll() returns DomQuery object is no matches
+		$this->assertInstanceOf(DOMQuery::class, qp($file, '#non-existing-selector')->wrapAll(''));
 	}
 
 	public function testWrapInner()


### PR DESCRIPTION
When `$this->matches->count()` is 0 in `QueryMutators::wrapAll()` it returns void, but the method is type hinted to return `DOMQuery` (the current object). 

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

If matches is empty and you call `->wrapAll()` it will return null.

## What is the new behavior?

If matches is empty and you call `->wrapAll()` it will return the `DOMQuery` object, as per the docblock return type.

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

Included in major release.
