### PR TITLE
Auto-flush GH Image Cache on new Tag

### DIFF
--- a/.github/workflows/badge-cache-flush.yml
+++ b/.github/workflows/badge-cache-flush.yml
@@ -1,0 +1,15 @@
+---
+name: Flush README.md Image Cache
+
+on:
+  push:
+    tags: '*'
+
+jobs:
+  flush:
+    name: Cleanup GitHub Image Cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: b3b00/refreshBadgesAction@v1.0.7
+        with:
+          repository: 'gravitypdf/querypath'


### PR DESCRIPTION
This will automatically clear the old badges from GitHub's image cache when a new release is tagged so outdated information isn't shown to users.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [X] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

GitHub caches the README.md badges and these can be out of sync after tagging a new release.

Issue Number: N/A

## What is the new behavior?

Automatically clear the GH image cache when pushing new Git Tag using new GitHub Action.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

