### PR TITLE
Mark as PHP8.3 Supported

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        php-versions: [ '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
         include:
           - php: '8.2'
             report: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 QueryPath Changelog
 ===========================
 
+# 3.2.3
+
+- Add PHP 8.3 Support
+
 # 3.2.2
 
 - Add PHP 8.2 Support

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "gravitypdf/querypath",
   "type": "library",
-  "description": "PHP library for HTML(5)/XML querying (CSS 4 or XPath) and processing (like jQuery) with PHP8.2 support",
+  "description": "PHP library for HTML(5)/XML querying (CSS 4 or XPath) and processing (like jQuery) with PHP8.3 support",
   "homepage": "https://github.com/gravitypdf/querypath",
   "license": "MIT",
   "keywords": [
@@ -23,7 +23,7 @@
     }
   ],
   "require": {
-    "php": "^7.1 || ~8.0.0 || ~8.1.0 || ~8.2.0",
+    "php": "^7.1 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
     "masterminds/html5": "^2.0"
   },
   "autoload": {


### PR DESCRIPTION
Update composer PHP requirements so the library can be installed with PHP8.3

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

You cannot install the library if you are running PHP8.3

Issue Number: N/A

## What is the new behavior?

You can install the library if you are running PHP8.3

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

