### PR TITLE
Psuedo-class selector :text producing errors and incorrect results

### DIFF
--- a/tests/Issues/Issue49Test.php
+++ b/tests/Issues/Issue49Test.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace QueryPathTests;
+
+class Issue49Test extends TestCase
+{
+	public function testCheckingForMatchingTextInputs(): void
+	{
+		$q = html5qp('<div><input name="text1" type="text" /><input name="text2" /></div>', 'div');
+
+		/* Check if the DOMNode or its children matches */
+		$this->assertTrue($q->is(':text'));
+		$this->assertCount(2, $q->find(':text'));
+
+		$textNode = $q->find('div')->contents()->eq(0);
+		$this->assertTrue($textNode->is(':text'));
+	}
+
+	public function testCheckingForEmptyTextInputs(): void
+	{
+		$q = html5qp('<div>Sample</div>', 'div');
+
+		/* Check if the DOMNode or its children matches */
+		$this->assertFalse($q->is(':text'));
+		$this->assertCount(0, $q->find(':text'));
+
+		/* check if a text node matches */
+		$textNode = $q->find('div')->contents()->eq(0);
+		$this->assertFalse($textNode->is(':text'));
+	}
+}


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

1. If doing `->is(':text')` on a text node an error is produced. 
2. If doing `->find(':text')` it won't match `<input />` tags without a type (which are considered text inputs). See https://api.jquery.com/text-selector/

Issue Number: https://github.com/GravityPDF/querypath/issues/49

## What is the new behavior?

TBA

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

TBA

## Other information

Unit tests are written. Code to pass the tests still to be written.
