### PR TITLE
Fix for :nth-child(n+B) to select B-th and all following elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ doc/*
 test/fakepear
 vendor/
 composer.lock
+.phpunit.result.cache
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ QueryPath Changelog
 # 4.0.2
 
 - Fix for :nth-child(n+B) to select B-th and all following elements
+- Fix for :nth-child(-n+B) to select first B elements
 - Update PHPUnit Test Suite to use @dataProvider in testPseudoClassNthChild() to reduce code repetition
 
 # 4.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ QueryPath Changelog
 # 4.0.2
 
 - Fix for :nth-child(n+B) to select B-th and all following elements
+- Update PHPUnit Test Suite to use @dataProvider in testPseudoClassNthChild() to reduce code repetition
 
 # 4.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 QueryPath Changelog
 ===========================
 
+# 4.0.2
+
+- Fix for :nth-child(n+B) to select B-th and all following elements
+
 # 4.0.1
 
 - Only define global functions qp(), htmlqp(), and html5qp() if they haven't been defined already.

--- a/src/CSS/QueryPathEventHandler.php
+++ b/src/CSS/QueryPathEventHandler.php
@@ -734,9 +734,15 @@ class QueryPathEventHandler implements EventHandler, Traverser
 			throw new ParseException("nth-child value is invalid.");
 		}
 
-		// Each of these is legal: 1, -1, and -. '-' is shorthand for -1.
+		// Each of these is legal: 1, -1, - and <empty>. '-' is shorthand for -1. <empty> is shorthand for 1
 		$aVal = trim($rule[0]);
-		$aVal = ($aVal == '-') ? -1 : (int) $aVal;
+		if ($aVal === '') {
+			$aVal = 1;
+		} elseif ($aVal === '-') {
+			$aVal = -1;
+		} else {
+			$aVal = (int) $aVal;
+		}
 
 		$bVal = ! empty($rule[1]) ? (int) trim($rule[1]) : 0;
 

--- a/tests/QueryPath/CSS/QueryPathEventHandlerTest.php
+++ b/tests/QueryPath/CSS/QueryPathEventHandlerTest.php
@@ -628,11 +628,12 @@ class QueryPathEventHandlerTest extends TestCase
 			//['i:nth-child(-2n)', 2, 'four'    ], // Not totally sure what should be returned here
 			['i:nth-child(4n)',   1, 'four', 0], // every fourth row
 			['i:nth-child(4n+1)', 2, 'five'   ], // first of every four rows
-			['i:nth-child(1)',    1, 'one', 0 ], // first row
+			['i:nth-child(1)',    1, 'one',  0], // first row
 			['i:nth-child(0n-0)', 0, null     ], // empty list
 			['i:nth-child(n+3)',  3, 'four'   ], // third+ lines
-			//['i:nth-child(0n+3)', 1, 'three'  ], // third element in a group of siblings
-			//['i:nth-child(-n+3)', 3, 'three'  ], // first three lines
+			['i:nth-child(-n+3)', 3, 'two'    ], // first three elements
+			['i:nth-child(-n+4)', 4, 'two'    ], // first four lines
+			['i:nth-child(0n+2)', 1, 'two',  0], // second element in a group of siblings
 		];
 	}
 

--- a/tests/QueryPath/CSS/QueryPathEventHandlerTest.php
+++ b/tests/QueryPath/CSS/QueryPathEventHandlerTest.php
@@ -714,6 +714,13 @@ class QueryPathEventHandlerTest extends TestCase
 		$matches = $handler->getMatches();
 		$this->assertEquals(0, $matches->count());
 
+		// Test nth-child(n+3) (3+ elements)
+		$handler = new QueryPathEventHandler($doc);
+		$handler->find('i:nth-child(n+3)');
+		$matches = $handler->getMatches();
+		$this->assertEquals(3, $matches->count());
+		$this->assertEquals('four', $this->nthMatch($matches, 1)->getAttribute('id'));
+
 		// Test nth-child(-n+3) (First three lines)
 		// $handler = new QueryPathEventHandler($doc);
 		// $handler->find('i:nth-child(-n+3)');


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

:nth-child(n+B) selects only B-th elements

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

:nth-child(n+B) selects B-th and all following elements
See: https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child#nth-childn7

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
