### PR TITLE
Additional fix for :nth-child(n+B)

### DIFF
--- a/src/CSS/DOMTraverser/PseudoClass.php
+++ b/src/CSS/DOMTraverser/PseudoClass.php
@@ -441,7 +441,6 @@ class PseudoClass
 		$parent = $node->parentNode;
 		if (empty($parent)
 			|| ($groupSize === 0 && $elementInGroup === 0)
-			|| ($groupSize > 0 && $elementInGroup > $groupSize)
 		) {
 			return false;
 		}

--- a/src/CSS/DOMTraverser/Util.php
+++ b/src/CSS/DOMTraverser/Util.php
@@ -149,6 +149,8 @@ class Util
 		$aVal = $matches[1] ?? 1;
 		if ($aVal === '-') {
 			$aVal = -1;
+		} elseif ($aVal === '') {
+			$aVal = 1;
 		} else {
 			$aVal = (int) $aVal;
 		}

--- a/tests/QueryPath/CSS/UtilTest.php
+++ b/tests/QueryPath/CSS/UtilTest.php
@@ -45,6 +45,7 @@ class UtilTest extends TestCase
 		$this->assertEquals([2, -1], Util::parseAnB('2n   -   1'));
 		// -n + 3
 		$this->assertEquals([-1, 3], Util::parseAnB('-n+3'));
+		$this->assertEquals([1,  3], Util::parseAnB('n+3'));
 
 		// Test invalid values
 		$this->assertEquals([0, 0], Util::parseAnB('obviously + invalid'));


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

:nth-child(n+B) selects only B-th elements

## What is the new behavior?

:nth-child(n+B) selects B-th and all following elements
See: https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child#nth-childn7

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

- This is an additional fix for PR [#56.](https://github.com/GravityPDF/querypath/pull/56) 
My previous PR didn't actually fix the nth-child(n+B) bug. Two duplicate functions exist for isNthChild() and parseAnB() logic. I fixed only one that passed the tests, but appearance doesn't affect the result. I didn't notice it last time.
Ideally, there should be no duplicated logic. But it's a task for the future refactoring.
- Also, there was an invalid test:
...
// BROKEN RULES -- these should always fail to match.
// 6n + 7;
...
This rule is actually valid for 20 elements. Every 6th element with an offset of 7 should match 3 elements but not 0. Rewrote this test to 6n+30 to fail
