### PR TITLE
Fix error when getting parents() for HTML elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ QueryPath Changelog
 - Fix for :nth-child(n+B) to select B-th and all following elements
 - Fix for :nth-child(-n+B) to select first B elements
 - Update PHPUnit Test Suite to use @dataProvider in testPseudoClassNthChild() to reduce code repetition
+- Fix error when getting parents() for HTML elements
 
 # 4.0.0
 

--- a/src/Helpers/QueryFilters.php
+++ b/src/Helpers/QueryFilters.php
@@ -796,26 +796,7 @@ trait QueryFilters
 	 */
 	public function parent($selector = null): Query
 	{
-		$found = new SplObjectStorage();
-		foreach ($this->matches as $m) {
-			while ($m->parentNode->nodeType !== XML_DOCUMENT_NODE) {
-				$m = $m->parentNode;
-				// Is there any case where parent node is not an element?
-				if ($m->nodeType === XML_ELEMENT_NODE) {
-					if (! empty($selector)) {
-						if (QueryPath::with($m, null, $this->options)->is($selector) > 0) {
-							$found->attach($m);
-							break;
-						}
-					} else {
-						$found->attach($m);
-						break;
-					}
-				}
-			}
-		}
-
-		return $this->inst($found, null);
+		return $this->getParentElements($selector, true);
 	}
 
 	/**
@@ -836,18 +817,44 @@ trait QueryFilters
 	 */
 	public function parents($selector = null): Query
 	{
+		return $this->getParentElements($selector, false);
+	}
+
+	/**
+	 * Get ancestor(s) of each element in the DOMQuery.
+	 *
+	 * If a selector is present, only matching ancestors will be retrieved.
+	 *
+	 * @param string|null $selector
+	 *  A valid CSS 3 Selector.
+	 * @param bool $immediate
+	 *  If function should return only the immediate parent
+	 *
+	 * @return DOMQuery
+	 *  A DOMNode object containing the matching ancestors.
+	 * @throws ParseException
+	 * @throws Exception
+	 */
+	private function getParentElements(?string $selector, bool $immediate): Query
+	{
 		$found = new SplObjectStorage();
 		foreach ($this->matches as $m) {
-			while ($m->parentNode->nodeType !== XML_DOCUMENT_NODE) {
+			while ($m->parentNode && $m->parentNode->nodeType !== XML_DOCUMENT_NODE) {
 				$m = $m->parentNode;
 				// Is there any case where parent node is not an element?
 				if ($m->nodeType === XML_ELEMENT_NODE) {
 					if (! empty($selector)) {
 						if (QueryPath::with($m, null, $this->options)->is($selector) > 0) {
 							$found->attach($m);
+							if ($immediate) {
+								break;
+							}
 						}
 					} else {
 						$found->attach($m);
+						if ($immediate) {
+							break;
+						}
 					}
 				}
 			}

--- a/tests/QueryPath/DOMQueryTest.php
+++ b/tests/QueryPath/DOMQueryTest.php
@@ -1676,6 +1676,8 @@ class DOMQueryTest extends TestCase
 		$this->assertEquals('root', qp($file, 'unary')->parent()->tag());
 		$this->assertEquals('root', qp($file, 'li')->parent('root')->tag());
 		$this->assertEquals(2, qp($file, 'li')->parent()->count());
+		$this->assertEquals(0, qp(DATA_HTML_FILE, 'html')->parent()->count());
+		$this->assertEquals(2, qp(DATA_HTML_FILE, 'table')->parents()->count());
 	}
 
 	public function testClosest()


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- Calling parents() on HTML elements throws error
- Calling parent() on HTML root element throws error

## What is the new behavior?

- No errors when calling parents()
- parent() on root element returns empty match

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Also, parent() and parent() logic were merged to getParentElements() to avoid duplication of code/logic. This is an optional suggestion. The primary fix is only one additional check in both these functions: "while ($m->parentNode && ..."
